### PR TITLE
Create CloudTrail event selector

### DIFF
--- a/infrastructure/lib/core/events.ts
+++ b/infrastructure/lib/core/events.ts
@@ -4,6 +4,7 @@ import * as targets from '@aws-cdk/aws-events-targets';
 import * as s3 from '@aws-cdk/aws-s3';
 import * as events from '@aws-cdk/aws-events';
 import * as lambda from '@aws-cdk/aws-lambda';
+import * as cloudtrail from '@aws-cdk/aws-cloudtrail'
 
 interface ApplicationEventsProps {
   processingStateMachine: sfn.IStateMachine;
@@ -16,6 +17,16 @@ export class ApplicationEvents extends cdk.Construct {
     super(scope, id);
 
     // Trigger Step Function from S3 Upload ------------------------------
+
+    const trail = new cloudtrail.Trail(this, 'CloudTrail', {
+      includeGlobalServiceEvents: false,
+      isMultiRegionTrail: false
+    });
+
+    trail.addS3EventSelector([{ bucket: props.uploadBucket }], {
+      includeManagementEvents: false,
+      readWriteType: cloudtrail.ReadWriteType.WRITE_ONLY
+    });
 
     const uploadRule = props.uploadBucket.onCloudTrailWriteObject('UploadRule', {});
 


### PR DESCRIPTION
Hi Dave, thanks for the great course :). After completing module 4 and uploading a document the Step Function is not triggered. I tried the P4 branch but had the same problem. This seems to be because the CloudTrail event selector is not created.  This change resolved the issue for me, you might want to update the course to add this step