### PR TITLE
fix(processing): typo in catchError.js

### DIFF
--- a/services/processing/catchError.js
+++ b/services/processing/catchError.js
@@ -14,7 +14,7 @@ const tableName = process.env.DYNAMO_DB_TABLE;
 exports.handler = async event => {
   // First function failing
   const filename =
-    Object.prototyle.hasOwnProperty.call(event, 'detail') && event.detail.requestParameters.key
+    Object.prototype.hasOwnProperty.call(event, 'detail') && event.detail.requestParameters.key
       ? event.detail.requestParameters.key
       : event.file.key;
 


### PR DESCRIPTION
I detected this typo that prevents the error handling in the Step Function from functioning properly.

It can be difficult to detect for a beginner so I think it should be a great idea to fix it.